### PR TITLE
add custom CSS and prop-based theming for data entry components

### DIFF
--- a/.github/workflows/publish_python.yml
+++ b/.github/workflows/publish_python.yml
@@ -1,9 +1,8 @@
 name: publish_python_package
 on:
-    workflow_dispatch:
-    push:
-        tags:
-            - '*'
+    release:
+        types: [published]
+
 jobs:
     publish:
         runs-on: ubuntu-latest
@@ -30,6 +29,9 @@ jobs:
                   pip install -r requirements.txt
                   pip install twine
                   npm i
+            - name: Sync version from Git Tag
+              run: |
+                  npm version ${{ github.ref_name }} --no-git-tag-version
             - name: Build tarball
               run: |
                   npm run build

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dashMpComponents
 Title: Dash components for the Materials Project
-Version: 0.5.0-rc.0
+Version: 0.5.0-rc.1
 Description: Dash components for the Materials Project
 Depends: R (>= 3.0.2)
 Imports: 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,26 @@ git commit -am "Update mp-react-components"
 npm version patch
 ```
 
+## Release procedures
+
+Dependency Configuration: Update the `@materialsproject/mp-react-components` dependency in `package.json`. Ensure you specify whether the release should track the `rc` or `next` distribution tag.
+
+The project uses Git tags to manage versioning. To trigger a new release, follow these steps:
+
+1. Tag the commit locally:
+
+```
+git tag -a <UPDATED_VERSION> -m "<DESCRIPTION OF CHANGES>"
+```
+
+2. Push the tag to GitHub:
+
+```
+git push origin <UPDATED_VERSION>
+```
+
+3. Finalize the Release: Navigate to the "Releases" tab on GitHub and publish the release based on the new tag. This triggers the CI/CD pipeline to stamp the version into package.json and publish to NPM/PyPI.
+
 ## Manually Create a production build and publish:
 
 1. Build your code:

--- a/dash_mp_components/metadata.json
+++ b/dash_mp_components/metadata.json
@@ -1695,6 +1695,16 @@
                 "type": {"name": "number"},
                 "required": false,
                 "description": ""
+            },
+            "styleInput": {
+                "type": {"name": "object"},
+                "required": false,
+                "description": ""
+            },
+            "styleSlider": {
+                "type": {"name": "object"},
+                "required": false,
+                "description": ""
             }
         }
     },
@@ -1740,6 +1750,11 @@
             },
             "active": {
                 "type": {"name": "bool"},
+                "required": false,
+                "description": ""
+            },
+            "styleLabel": {
+                "type": {"name": "object"},
                 "required": false,
                 "description": ""
             }
@@ -1987,6 +2002,11 @@
             },
             "inclusiveTickBounds": {
                 "type": {"name": "bool"},
+                "required": false,
+                "description": ""
+            },
+            "debounce": {
+                "type": {"name": "number"},
                 "required": false,
                 "description": ""
             },

--- a/dash_mp_components/package-info.json
+++ b/dash_mp_components/package-info.json
@@ -1,6 +1,6 @@
 {
     "name": "@materialsproject/dash-mp-components",
-    "version": "0.5.0-rc.0",
+    "version": "0.5.0-rc.1",
     "description": "Dash components for the Materials Project",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@materialsproject/dash-mp-components",
-    "version": "0.5.0-rc.1",
-    "description": "Dash components for the Materials Project",
+    "version": "0.0.0-automated",
+    "description": "Dash components for the Materials Project. Version is managed by Git tags in CI/CD",
     "repository": {
         "type": "git",
         "url": "git://github.com/materialsproject/dash-mp-components.git"

--- a/src/lib/components/data-entry/DualRangeSlider.react.js
+++ b/src/lib/components/data-entry/DualRangeSlider.react.js
@@ -25,4 +25,6 @@ DualRangeSlider.propTypes = {
     ticks: PropTypes.number,
     inclusiveTickBounds: PropTypes.bool,
     debounce: PropTypes.number,
+    styleInput: PropTypes.object,
+    styleSlider: PropTypes.object,
 };

--- a/src/lib/components/data-entry/FilterField.react.js
+++ b/src/lib/components/data-entry/FilterField.react.js
@@ -22,4 +22,5 @@ FilterField.propTypes = {
     units: PropTypes.string,
     dois: PropTypes.arrayOf(PropTypes.string),
     active: PropTypes.bool,
+    styleLabel: PropTypes.object,
 };

--- a/src/lib/components/data-entry/RangeSlider.react.js
+++ b/src/lib/components/data-entry/RangeSlider.react.js
@@ -24,4 +24,6 @@ RangeSlider.propTypes = {
     ticks: PropTypes.number,
     inclusiveTickBounds: PropTypes.bool,
     debounce: PropTypes.number,
+    styleInput: PropTypes.object,
+    styleSlider: PropTypes.object,
 };


### PR DESCRIPTION
-  Release Workflow Optimization: Integrated automated versioning for NPM. The workflow now uses npm version ${{ github.ref_name }} --no-git-tag-version to ensure the published package version strictly matches the GitHub tag/release. No longer need to have code version in project.json.

Related to [PR](https://github.com/materialsproject/mp-react-components/pull/751)
