### PR TITLE
add timeout to failed test

### DIFF
--- a/.github/workflows/selenium_tests.yml
+++ b/.github/workflows/selenium_tests.yml
@@ -1,6 +1,7 @@
 name: selenium_tests
 
 on:
+    workflow_dispatch:
     push:
         branches:
             - main

--- a/tests/scene_3d_test.py
+++ b/tests/scene_3d_test.py
@@ -213,7 +213,7 @@ class SVG3DScene(unittest.TestCase):
 
     def test_scene_switcher(self):
         # check if adding a new scene clean the old one
-        dropdown = self.dash_duo.find_element('#demo-dropdown input')
+        dropdown = self.dash_duo.find_element('#demo-dropdown input', timeout=10)
         dropdown.send_keys('Scene2')
         dropdown.send_keys(Keys.ENTER)
         time.sleep(1)


### PR DESCRIPTION
Getting `E       selenium.common.exceptions.NoSuchElementException: Message: no such element: Unable to locate element: {"method":"css selector","selector":"#demo-dropdown input"}` in `e2e-test`

Fix:
Add `timeout=10` to `dropdown = self.dash_duo.find_element('#demo-dropdown input')`