### PR TITLE
Update workflows

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "author": "Materials Project Team <feedback@materialsproject.org>",
     "license": "BSD",
     "dependencies": {
-        "@materialsproject/mp-react-components": "0.5.1-rc.4",
+        "@materialsproject/mp-react-components": "0.5.1-rc.6",
         "file-loader": "^5.1.0",
         "prettier": "^1.19.1",
         "process": "^0.11.10",


### PR DESCRIPTION
remove `postversion": "git push && git push --tags` from `package.json`
It conflicts with `npm version ${{ github.ref_name }} --no-git-tag-version` in workflows