### PR TITLE
build and publish a wheel

### DIFF
--- a/.github/workflows/publish_python.yml
+++ b/.github/workflows/publish_python.yml
@@ -31,17 +31,17 @@ jobs:
                   sudo apt-get update
                   python -m pip install --upgrade pip
                   pip install -r requirements.txt
-                  pip install twine
+                  pip install twine build
                   npm install --legacy-peer-deps
 
             - name: Sync version from Git Tag
               run: |
                   npm version ${{ github.ref_name }} --no-git-tag-version
 
-            - name: Build tarball
+            - name: Build distributions
               run: |
                   npm run build
-                  python setup.py sdist
+                  python -m build
 
             - name: Publish package to NPM
               run: |

--- a/README.md
+++ b/README.md
@@ -147,13 +147,13 @@ git push origin <UPDATED_VERSION>
     ```
     $ npm run build
     ```
-2. Create a Python tarball
+2. Create a Python tarball and wheel
 
     ```
-    $ python setup.py sdist
+    $ python -m build
     ```
 
-    This distribution tarball will get generated in the `dist/` folder
+    These distribution files will get generated in the `dist/` folder
 
 3. Test your tarball by copying it into a new environment and installing it locally:
 


### PR DESCRIPTION
Publish a wheel, as well as a source distribution.

Direct invocation of `setup.py` is deprecated, I have used `build`.  You may need to install `build` to run this locally (just as today you presumably need to install `twine` to publish).